### PR TITLE
Fixed malformed haddock comment. ...

### DIFF
--- a/rate-limited-io.cabal
+++ b/rate-limited-io.cabal
@@ -1,5 +1,5 @@
 name:                rate-limited-io
-version:             0.5.0.0
+version:             0.5.0.1
 synopsis:
   A library that facilitates graceful handling of IO actions which are rate limited by some external party (e.g. connecting to the Twitter api).    
 description:         

--- a/src/Control/Concurrent/RateLimitedIO.hs
+++ b/src/Control/Concurrent/RateLimitedIO.hs
@@ -204,7 +204,7 @@ performJob policy@BackoffPolicy{initialDelayMilliseconds, maxExponent}
 
     newExponent collisions
       | collisions >= maxExponent = collisions
-        -- ^ don't go crazy with the backoff exponent.
+        -- don't go crazy with the backoff exponent.
       | otherwise = collisions + 1
 
     pop = atomically $ modifyTVar throttledT (delete jobId)


### PR DESCRIPTION
Using haddock syntax on something that is not a documentable entity
causes haddock to crash, which is especially problematic when downstream
packages are trying to build a complete set of haddocks.